### PR TITLE
Include notification task with include_role instead of include_tasks

### DIFF
--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -12,7 +12,8 @@
 
 
 - name: call optional notifier for newly-created buckets
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       created new S3 bucket{% if _aws_s3_new_buckets.__len__() != 1 %}s{% endif %}
@@ -26,7 +27,8 @@
     _aws_s3_new_buckets
 
 - name: call optional notifier for modified buckets
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       modified bucket
@@ -42,7 +44,8 @@
     changed_buckets
 
 - name: call optional notifier for untracked buckets
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message:
     attachments:
@@ -66,7 +69,8 @@
 
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       finished running role <b>aws-s3</b>

--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -17,7 +17,8 @@
          | sort }}
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       started running role <b>aws-s3</b>


### PR DESCRIPTION
This is the proper way to include tasks from another role with modern Ansible.